### PR TITLE
Update Swedish translation

### DIFF
--- a/Snip/Resources/Strings.se-SE.txt
+++ b/Snip/Resources/Strings.se-SE.txt
@@ -31,33 +31,33 @@ VLCIsNotRunning=VLC körs inte just nu
 
 ; This text is saved to the Snip.txt file when no track is playing in the
 ; selected media file or when the user stops/pauses a playing track.
-NoTrackPlaying=Inget Spår Spelas
+NoTrackPlaying=Inget spår spelas
 
 ; This text is displayed on the right-click context menu and, when clicked,
 ; will open up the "Set Output Format" form where the user can customize how
 ; the text will look when saved to any of the text files.
-SetOutputFormat=Ställ In Utgående Format
+SetOutputFormat=Ställ in utgående format
 
 ; This text is displayed on the right-click context menu and, when enabled,
 ; will save the artist information and song information to separate text files
 ; on the harddrive.
-SaveInformationSeparately=Spara Information Separat
+SaveInformationSeparately=Spara information separat
 
 ; This text is displayed on the right-click context menu and, when enabled,
 ; will download and save album artwork for the currently playing track to the
 ; harddrive.
-SaveAlbumArtwork=Spara Albumgrafik
+SaveAlbumArtwork=Spara albumgrafik
 
 ; This text is displayed on the right-click context menu and, when enabled,
 ; will save the artwork to a subdirectory using the trackid information
 ; provided by Spotify as the filename.  Each track will save its own album
 ; artwork and the next time that track is played it will use the saved file
 ; instead of redownloading it each time.
-KeepSpotifyAlbumArtwork=Spara Spotify Albumgrafik
+KeepSpotifyAlbumArtwork=Spara Spotify albumgrafik
 
 ; These texts are displayed under a sub-menu of "Keep Spotify Album Artwork"
 ; and it refers to the image resolution of the artwork to be downloaded.
-ImageResolutionTiny=Mycket Liten
+ImageResolutionTiny=Mycket liten
 ImageResolutionSmall=Liten
 ImageResolutionMedium=Mellan
 ImageResolutionLarge=Stor
@@ -65,7 +65,7 @@ ImageResolutionLarge=Stor
 ; This text is displayed on the right-click context menu and, when enabled,
 ; will create a file called Snip_History.txt where it will append each track
 ; played to the end of the file, effectively creating a play history.
-SaveTrackHistory=Spara Spårhistorik
+SaveTrackHistory=Spara spårhistorik
 
 ; This text is displayed on the right-click context menu and, when enabled,
 ; will cause Snip.txt to be emptied out when no track is playing.  If this
@@ -91,15 +91,15 @@ iTunesException=Please exit iTunes and reselect iTunes from within Snip.
 ######################
 
 ; This text is displayed as the title of the Output Format Form.
-SetOutputFormatForm=Ställ In Utgående Format
+SetOutputFormatForm=Ställ in utgående format
 
 ; These texts refer to setting how specific output looks when saved to any of
 ; the text files.  The $t, $a, and $l variables will be filled in with the
 ; track, artist, and album information of the currently playing track.
-SetTrackFormat=Ställ In Spårformat ($t):
-SetSeparatorFormat=Ställ In Separatorformat:
-SetArtistFormat=Ställ In Artistformat ($a):
-SetAlbumFormat=Ställ In Albumformat ($l):
+SetTrackFormat=Ställ in spårformat ($t):
+SetSeparatorFormat=Ställ in separatorformat:
+SetArtistFormat=Ställ in artistformat ($a):
+SetAlbumFormat=Ställ in albumformat ($l):
 
 ; This text is displayed on the buttons within this form.  Clicking the
 ; Defaults button will restore the output format settings to their default

--- a/Snip/Resources/Strings.se-SE.txt
+++ b/Snip/Resources/Strings.se-SE.txt
@@ -36,7 +36,7 @@ NoTrackPlaying=Inget spår spelas
 ; This text is displayed on the right-click context menu and, when clicked,
 ; will open up the "Set Output Format" form where the user can customize how
 ; the text will look when saved to any of the text files.
-SetOutputFormat=Ställ in utgående format
+SetOutputFormat=Ställ in outputformat
 
 ; This text is displayed on the right-click context menu and, when enabled,
 ; will save the artist information and song information to separate text files
@@ -91,7 +91,7 @@ iTunesException=Var god avsluta iTunes och välj iTunes igen innuti Snip.
 ######################
 
 ; This text is displayed as the title of the Output Format Form.
-SetOutputFormatForm=Ställ in utgående format
+SetOutputFormatForm=Ställ in outputformat
 
 ; These texts refer to setting how specific output looks when saved to any of
 ; the text files.  The $t, $a, and $l variables will be filled in with the

--- a/Snip/Resources/Strings.se-SE.txt
+++ b/Snip/Resources/Strings.se-SE.txt
@@ -71,12 +71,12 @@ SaveTrackHistory=Spara spårhistorik
 ; will cause Snip.txt to be emptied out when no track is playing.  If this
 ; option is disabled then the text from "NoTrackPlaying" will be saved to
 ; Snip.txt.
-EmptyFile=Empty File If No Track Playing
+EmptyFile=Töm fil om inget spelas
 
 ; This text is displayed on the right-click context menu and, when enabled,
 ; will cause Snip to register global hotkeys that can be used to control the
 ; selected media player from anywhere.
-EnableHotkeys=Enable Hotkeys
+EnableHotkeys=Sätt på kortkommandon
 
 ; This text is displayed on the right-click context menu and, when clicked,
 ; will exit the application.
@@ -84,7 +84,7 @@ ExitApplication=Avsluta
 
 ; This text is displayed in a MessageBox pop-up when there is a COM exception
 ; caused by trying to load the iTunes COM library.
-iTunesException=Please exit iTunes and reselect iTunes from within Snip.
+iTunesException=Var god avsluta iTunes och välj iTunes igen innuti Snip.
 
 ######################
 # Output Format Form #

--- a/Snip/Resources/Strings.se-SE.txt
+++ b/Snip/Resources/Strings.se-SE.txt
@@ -46,14 +46,14 @@ SaveInformationSeparately=Spara information separat
 ; This text is displayed on the right-click context menu and, when enabled,
 ; will download and save album artwork for the currently playing track to the
 ; harddrive.
-SaveAlbumArtwork=Spara albumgrafik
+SaveAlbumArtwork=Spara omslagsbild
 
 ; This text is displayed on the right-click context menu and, when enabled,
 ; will save the artwork to a subdirectory using the trackid information
 ; provided by Spotify as the filename.  Each track will save its own album
 ; artwork and the next time that track is played it will use the saved file
 ; instead of redownloading it each time.
-KeepSpotifyAlbumArtwork=Spara Spotify albumgrafik
+KeepSpotifyAlbumArtwork=Spara Spotify-omslagsbild
 
 ; These texts are displayed under a sub-menu of "Keep Spotify Album Artwork"
 ; and it refers to the image resolution of the artwork to be downloaded.
@@ -97,7 +97,7 @@ SetOutputFormatForm=Ställ in utgående format
 ; the text files.  The $t, $a, and $l variables will be filled in with the
 ; track, artist, and album information of the currently playing track.
 SetTrackFormat=Ställ in spårformat ($t):
-SetSeparatorFormat=Ställ in separatorformat:
+SetSeparatorFormat=Ställ in särskiljningsformat:
 SetArtistFormat=Ställ in artistformat ($a):
 SetAlbumFormat=Ställ in albumformat ($l):
 


### PR DESCRIPTION
It has been a while since the initial merge of the Swedish translation, and in the meantime I have learnt one or two things about translating applications (such as Twitter, HabitRPG, Financius, Urban Dictionary, etc.) into the Swedish language.

A few months ago I looked back at the translation I had done for this project and started noticing issues. I ended up patching them and discussing the changes that I had made with friends of mine and a dear mother who has previously worked as a Swedish teacher.

Most of this patch is done as I've only got one question left that needs answering, so that I can patch, commit, and update the pull request before it is closed or merged. Once that is done I'll comment back with a stamp of approval.

~~The question that needs answering is related to the string `SetOutputFormat=Set Output Format`. The direct translation of the current one I have is `Set Outgoing Format` and sounds really strange in Swedish. My question is if this rather could be translated as `Set Text Format` or `Set Format For Text`. If none of that works I could take another route as we in Swedish also use the word "output", it is just slang but would probably end up being just as interpretable due to this application's target audience now when I come to think of it.~~ Look down below for an interpretable version of this paragraph.

What do you think? Should I stick to the slang version or should I translate one of the other two suggested versions?