### PR TITLE
Add album art support for Spotify via the Web API

### DIFF
--- a/Snip/Players/Spotify.cs
+++ b/Snip/Players/Spotify.cs
@@ -136,11 +136,56 @@ namespace Winter
                     {
                         this.SpotifyTrackChanged(this, EventArgs.Empty);
                     }
+
+                    if (Globals.SaveAlbumArtwork)
+                    {
+                        string albumId = jsonSummary.track.album_resource.uri.Replace("spotify:album:", "");
+                        SaveAlbumArt(albumId);
+                    }
+                    else
+                    {
+                        this.SaveBlankImage();
+                    }
                 }
                 else
                 {
                     TextHandler.UpdateText(Globals.ResourceManager.GetString("NoTrackPlaying"));
                 }
+            }
+        }
+
+        private void SaveAlbumArt(string albumId)
+        {
+            string result = String.Empty;
+
+            Uri requestUri = new Uri("https://api.spotify.com/v1/albums/" + albumId);
+
+            using (WebClient client = new WebClient())
+            {
+                result = client.DownloadString(requestUri);
+            }
+
+            dynamic jsonSummary = SimpleJson.DeserializeObject(result);
+
+            string albumArtUri = String.Empty;
+            switch (Globals.ArtworkResolution)
+            {
+                case Globals.AlbumArtworkResolution.Tiny: case Globals.AlbumArtworkResolution.Small:
+                    albumArtUri = jsonSummary.images[2].url;
+                    break;
+
+                case Globals.AlbumArtworkResolution.Medium:
+                    albumArtUri = jsonSummary.images[1].url;
+                    break;
+
+                case Globals.AlbumArtworkResolution.Large:
+                    albumArtUri = jsonSummary.images[0].url;
+                    break;
+            }
+
+            using (WebClient client = new WebClient())
+            {
+                client.DownloadFile(new Uri(albumArtUri), this.DefaultArtworkFilePath);
             }
         }
 

--- a/Snip/Players/Spotify.cs
+++ b/Snip/Players/Spotify.cs
@@ -44,6 +44,9 @@ namespace Winter
 
         private bool spotifyTokensObtained = false;
 
+        private string lastAlbumId = String.Empty;
+        private Globals.AlbumArtworkResolution lastResolution;
+
         public override void Load()
         {
             RunSpotifyWebHelperIfNotRunning();
@@ -140,7 +143,12 @@ namespace Winter
                     if (Globals.SaveAlbumArtwork)
                     {
                         string albumId = jsonSummary.track.album_resource.uri.Replace("spotify:album:", "");
-                        SaveAlbumArt(albumId);
+                        if (lastAlbumId != albumId || lastResolution != Globals.ArtworkResolution)
+                        {
+                            SaveAlbumArt(albumId);
+                        }
+                        lastAlbumId = albumId;
+                        lastResolution = Globals.ArtworkResolution;
                     }
                     else
                     {


### PR DESCRIPTION
This pull request adds support for album art downloading for Spotify which has been missing since the last big changes. It uses the Spotify Web API, specifically the `/v1/albums/` endpoint. This endpoint does not require any API key.