### PR TITLE
Change WebClient encoding to UTF-8 to better support special chars in Spotify

### DIFF
--- a/Snip/Players/Spotify.cs
+++ b/Snip/Players/Spotify.cs
@@ -21,6 +21,8 @@
 // Sections of this code are from:
 // https://github.com/ikkentim/Spotify
 
+using System.Text;
+
 namespace Winter
 {
     using System;
@@ -321,6 +323,7 @@ namespace Winter
             using (WebClient webClient = new WebClient())
             {
                 webClient.Headers.Set("Origin", "https://embed.spotify.com");
+                webClient.Encoding = Encoding.UTF8;
 
                 result = webClient.DownloadString(address);
             }


### PR DESCRIPTION
Previously the WebClient used the Windows default charset, Windows-1252, which caused some strange characters, for example "Tiësto" was rendered as "TiÃ«sto". This patch changes the encoding in the WebClient to UTF-8.