### PR TITLE
Updated Dutch (NL) translations

### DIFF
--- a/Snip/Resources/Strings.nl-NL.txt
+++ b/Snip/Resources/Strings.nl-NL.txt
@@ -31,29 +31,29 @@ VLCIsNotRunning=VLC draait nu niet
 
 ; This text is saved to the Snip.txt file when no track is playing in the
 ; selected media file or when the user stops/pauses a playing track.
-NoTrackPlaying=Er speelt geen Track
+NoTrackPlaying=Er speelt geen track
 
 ; This text is displayed on the right-click context menu and, when clicked,
 ; will open up the "Set Output Format" form where the user can customize how
 ; the text will look when saved to any of the text files.
-SetOutputFormat=Verander output opmaak
+SetOutputFormat=Opmaak voor uitvoer instellen
 
 ; This text is displayed on the right-click context menu and, when enabled,
 ; will save the artist information and song information to separate text files
 ; on the harddrive.
-SaveInformationSeparately=Sla informatie los op
+SaveInformationSeparately=Sla informatie apart op
 
 ; This text is displayed on the right-click context menu and, when enabled,
 ; will download and save album artwork for the currently playing track to the
 ; harddrive.
-SaveAlbumArtwork=Sla Album Artwork op
+SaveAlbumArtwork=Sla albumillustraties op
 
 ; This text is displayed on the right-click context menu and, when enabled,
 ; will save the artwork to a subdirectory using the trackid information
 ; provided by Spotify as the filename.  Each track will save its own album
 ; artwork and the next time that track is played it will use the saved file
 ; instead of redownloading it each time.
-KeepSpotifyAlbumArtwork=Behoud Spotify Album Artwork
+KeepSpotifyAlbumArtwork=Behoud Spotify albumillustratie
 
 ; These texts are displayed under a sub-menu of "Keep Spotify Album Artwork"
 ; and it refers to the image resolution of the artwork to be downloaded.
@@ -65,46 +65,46 @@ ImageResolutionLarge=Groot
 ; This text is displayed on the right-click context menu and, when enabled,
 ; will create a file called Snip_History.txt where it will append each track
 ; played to the end of the file, effectively creating a play history.
-SaveTrackHistory=Sla Track geschiedenis op
+SaveTrackHistory=Sla trackgeschiedenis op
 
 ; This text is displayed on the right-click context menu and, when enabled,
 ; will cause Snip.txt to be emptied out when no track is playing.  If this
 ; option is disabled then the text from "NoTrackPlaying" will be saved to
 ; Snip.txt.
-EmptyFile=Empty File If No Track Playing
+EmptyFile=Bestand leegmaken als er geen track speelt
 
 ; This text is displayed on the right-click context menu and, when enabled,
 ; will cause Snip to register global hotkeys that can be used to control the
 ; selected media player from anywhere.
-EnableHotkeys=Enable Hotkeys
+EnableHotkeys=Sneltoetsen inschakelen
 
 ; This text is displayed on the right-click context menu and, when clicked,
 ; will exit the application.
-ExitApplication=Sluit
+ExitApplication=Sluiten
 
 ; This text is displayed in a MessageBox pop-up when there is a COM exception
 ; caused by trying to load the iTunes COM library.
-iTunesException=Please exit iTunes and reselect iTunes from within Snip.
+iTunesException=Sluit alstublieft iTunes af en selecteer opnieuw iTunes in Snip.
 
 ######################
 # Output Format Form #
 ######################
 
 ; This text is displayed as the title of the Output Format Form.
-SetOutputFormatForm=Stel output opmaak in
+SetOutputFormatForm=Stel opmaak uitvoer in
 
 ; These texts refer to setting how specific output looks when saved to any of
 ; the text files.  The $t, $a, and $l variables will be filled in with the
 ; track, artist, and album information of the currently playing track.
-SetTrackFormat=Stel Track Opmaak in ($t):
+SetTrackFormat=Stel opmaak Track in ($t):
 SetSeparatorFormat=Stel scheidingsteken in:
-SetArtistFormat=Stel Artiest Opmaak in ($a):
-SetAlbumFormat=Stel Album Opmaak in($l):
+SetArtistFormat=Stel opmaak Artiest in ($a):
+SetAlbumFormat=Stel opmaak Album in($l):
 
 ; This text is displayed on the buttons within this form.  Clicking the
 ; Defaults button will restore the output format settings to their default
 ; appearance.  Clicking the Save button will save the user-set appearance.
-ButtonDefaults=Standaarden
+ButtonDefaults=Standaardwaarden
 ButtonSave=Opslaan
 
 ; These will most likely not need to be translated.  However, if your locale


### PR DESCRIPTION
Improved capitalization, word order, word and whitespace usage and translated new strings.