### PR TITLE
SetNotifyIconText adjustments

### DIFF
--- a/Snip/TextHandler.cs
+++ b/Snip/TextHandler.cs
@@ -42,16 +42,17 @@ namespace Winter
 
                 if (text.Length >= maxLength)
                 {
-                    maxLength -= 3; //need to ensure space to append "..." to the end of the string
+                    maxLength -= 4; //need to ensure space to append "..." to the end of the string
 
-                    //LastIndexOf will search backwards from the specified index to find the specified char (space)
-                    //subtract one so that we get the index of char preceding the located space.
-                    //we add it back in with string.format
-                    int nextSpace = text.LastIndexOf(' ', maxLength) - 1; 
+                    //LastIndexOf will search backwards from the specified index, this means that
+                    //we search maxLength + 1 characters to find the specified char (space)
+                    //this index gets treated as a length (from index 0) in text.Substring,
+                    //which implicitly removes the space from the resultant string 
+                    int nextSpace = text.LastIndexOf(' ', maxLength); 
 
                     //in the event that we don't find a space, we need to ensure there is space for us to add on in
                     //hence the maxLength - 1
-                    text = string.Format(CultureInfo.CurrentCulture, "{0} ...", text.Substring(0, (nextSpace > 0) ? nextSpace : (maxLength - 1)).Trim());
+                    text = string.Format(CultureInfo.CurrentCulture, "{0} ...", text.Substring(0, (nextSpace > 0) ? nextSpace : maxLength));
                 }
 
                 Type t = typeof(NotifyIcon);

--- a/Snip/TextHandler.cs
+++ b/Snip/TextHandler.cs
@@ -52,7 +52,7 @@ namespace Winter
 
                     //in the event that we don't find a space, we need to ensure there is space for us to add on in
                     //hence the maxLength - 1
-                    text = string.Format(CultureInfo.CurrentCulture, "{0} ...", text.Substring(0, (nextSpace > 0) ? nextSpace : maxLength));
+                    text = string.Format(CultureInfo.CurrentCulture, "{0} ...", text.Substring(0, (nextSpace > 0) ? nextSpace : maxLength).Trim());
                 }
 
                 Type t = typeof(NotifyIcon);

--- a/Snip/TextHandler.cs
+++ b/Snip/TextHandler.cs
@@ -36,13 +36,22 @@ namespace Winter
         {
             if (!string.IsNullOrEmpty(text))
             {
-                int maxLength = 120; // 128 max length minus 8 to stop issues with string length crashing the program
+                text = text.Trim(); //trim trailing spaces
+
+                int maxLength = 127; // 128 max length
 
                 if (text.Length >= maxLength)
                 {
-                    int nextSpace = text.LastIndexOf(' ', maxLength);
+                    maxLength -= 3; //need to ensure space to append "..." to the end of the string
 
-                    text = string.Format(CultureInfo.CurrentCulture, "{0} ...", text.Substring(0, (nextSpace > 0) ? nextSpace : maxLength).Trim());
+                    //LastIndexOf will search backwards from the specified index to find the specified char (space)
+                    //subtract one so that we get the index of char preceding the located space.
+                    //we add it back in with string.format
+                    int nextSpace = text.LastIndexOf(' ', maxLength) - 1; 
+
+                    //in the event that we don't find a space, we need to ensure there is space for us to add on in
+                    //hence the maxLength - 1
+                    text = string.Format(CultureInfo.CurrentCulture, "{0} ...", text.Substring(0, (nextSpace > 0) ? nextSpace : (maxLength - 1)).Trim());
                 }
 
                 Type t = typeof(NotifyIcon);

--- a/Snip/TextHandler.cs
+++ b/Snip/TextHandler.cs
@@ -42,7 +42,7 @@ namespace Winter
 
                 if (text.Length >= maxLength)
                 {
-                    maxLength -= 4; //need to ensure space to append "..." to the end of the string
+                    maxLength -= 4; //need to ensure space to append " ..." to the end of the string
 
                     //LastIndexOf will search backwards from the specified index, this means that
                     //we search maxLength + 1 characters to find the specified char (space)
@@ -50,8 +50,6 @@ namespace Winter
                     //which implicitly removes the space from the resultant string 
                     int nextSpace = text.LastIndexOf(' ', maxLength); 
 
-                    //in the event that we don't find a space, we need to ensure there is space for us to add on in
-                    //hence the maxLength - 1
                     text = string.Format(CultureInfo.CurrentCulture, "{0} ...", text.Substring(0, (nextSpace > 0) ? nextSpace : maxLength).Trim());
                 }
 


### PR DESCRIPTION
Alternative to https://github.com/dlrudie/Snip/pull/73

Should fix https://github.com/dlrudie/Snip/issues/72 and https://github.com/dlrudie/Snip/issues/67

This code will not attempt to trim string that are able to fit within the original length restriction of 127 characters (with one exception). 

I've added a fair amount of comments explaining what the code is doing.

I've only tested this briefly, but it should function without crashing in all cases.

I'm not actually sure what causes the crash, since the stack-trace posted in https://github.com/dlrudie/Snip/issues/72 suggest the code errors out at text.LastIndexOf, which would only happen if the string had a length == maxLength. but the strings posted in these issues do not seem to fit this criteria. This hypothetical crash would not occur with this code, as maxLength will always be less than text.length when we call LastIndexOf.

On a side note, the comment for this function states that it will truncate the string if over 128 characters, however, the maxLength was set to 127 (which I have reverted it to) and the if statement
```
if (text.Length >= maxLength)
```
will mean code will get trimmed if it is exactly maxLength long (a rare occasion?). only string 126 or less in length would pass untrimmed. is this the intentional behaviour? (i,e. to have a max string length of 126 characters instead of 127 or 128?)