### PR TITLE
Fix #101 incorrect track titles with Spotify

### DIFF
--- a/Snip/Players/Spotify.cs
+++ b/Snip/Players/Spotify.cs
@@ -83,14 +83,19 @@ namespace Winter
                                     {
                                         jsonSummary = SimpleJson.DeserializeObject(jsonSummary.tracks["items"].ToString());
 
-                                        TextHandler.UpdateText(
-                                            jsonSummary[0].name.ToString(),
-                                            jsonSummary[0].artists[0].name.ToString(),
-                                            jsonSummary[0].album.name.ToString());
-
-                                        if (Globals.SaveAlbumArtwork)
+                                        foreach (dynamic song in jsonSummary)
                                         {
-                                            this.HandleSpotifyAlbumArtwork(jsonSummary[0].name.ToString());
+                                            if (spotifyTitle.Contains(song.name) && spotifyTitle.Contains(song.artists[0].name))
+                                            {
+                                                TextHandler.UpdateText(song.name.ToString(), song.artists[0].name.ToString(), song.album.name.ToString());
+
+                                                if (Globals.SaveAlbumArtwork)
+                                                {
+                                                    this.HandleSpotifyAlbumArtwork(song.name.ToString());
+                                                }
+
+                                                break;
+                                            }
                                         }
                                     }
                                     else


### PR DESCRIPTION
Now iterates over all the search returns and makes sure the window title contains the song/artist before it as the current song.

Like I said I am not a C# dev, so feel free to rework this to meet your code standards. This is just a proof of concept, but it does work (from my testing).