### PR TITLE
Fixed VLC Player Trimming Titles Prematurely

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -42,3 +42,6 @@ Contributors
 
 * jingtongtangflee
   * Czech translation
+  
+* KingCrazy
+  * Fix for VLC player trimming titles prematurely

--- a/Snip/Players/VLC.cs
+++ b/Snip/Players/VLC.cs
@@ -48,17 +48,25 @@ namespace Winter
                 {
                     vlcTitle = vlcTitle.Substring(0, lastHyphen).Trim();
 
+                    string vlcExtension = System.IO.Path.GetExtension(vlcTitle);
+
                     if (Globals.SaveAlbumArtwork)
                     {
                         this.SaveBlankImage();
                     }
 
                     // Filter file extension
-                    int lastDot = vlcTitle.LastIndexOf('.');
-
-                    if (lastDot > 0)
+                    // VLC doesn't always have file extensions show in the title.
+                    // The previous code would sometimes cut song titles prematurely if there was no extension in the title.
+                    // If there's an extension, we'll trim it. Otherwise, we won't do anything to the string.
+                    if (vlcExtension.Length > 0)
                     {
-                        vlcTitle = vlcTitle.Substring(0, lastDot).Trim();
+                        int lastDot = vlcTitle.LastIndexOf(vlcExtension);
+
+                        if (lastDot > 0)
+                        {
+                            vlcTitle = vlcTitle.Substring(0, lastDot).Trim();
+                        }
                     }
 
                     TextHandler.UpdateText(vlcTitle);


### PR DESCRIPTION
Edits **VLC.cs** and updates **Authors.md** (Sorry, forgot to put that in the commit title! I was fumbling with forks, so my original series of commits was lost to an incorrect repo)

VLC does not always show the extensions of songs in the title. However, Snip would look for any "." in the title, assuming it to be the beginning of an extension. This was evident when streaming YouTube videos (which do not have extensions) featuring "." somewhere in the title.

(This is my first attempt to contribute to an open source project, so I apologize if I did something wrong. Please feel free to tell me if there's something I need to change!)