### PR TITLE
added Winamp and Foobar2000 album support

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -42,3 +42,6 @@ Contributors
 
 * jingtongtangflee
   * Czech translation
+
+* kaimi
+  * Winamp and Foobar2000 album support

--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ SUPPORTED FEATURES FOR PLAYERS
 ------------------------------
 * **Spotify:** Artist, Track, Album, Artwork
 * **iTunes:** Artist, Track, Album, Artwork
-* **Winamp:** Artist, Track
-* **foobar2000:** Artist, Track
+* **Winamp:** Artist, Track, Album
+* **foobar2000:** Artist, Track, Album
 * **VLC:** Nothing (It uses whatever the titlebar says)
 
 WINAMP
@@ -49,7 +49,7 @@ Inside Winamp open up the options window.
     when possible" is enabled.
 
 Then you need to edit the formatting to look like this:
-%title% – %artist%
+%title% – %artist% – %album%
 
 Note
 ----
@@ -65,7 +65,7 @@ Inside foobar2000 open up the preferences window.
 
 Expand the Display options and select Default User Interface.  At the bottom
 of the window you will need to change "Window title" to look like this:
-%title% – %artist%
+%title% – %artist% – %album%
 
 Note
 ----

--- a/Snip/Players/Winamp.cs
+++ b/Snip/Players/Winamp.cs
@@ -61,7 +61,7 @@ namespace Winter
                             {
                                 // Winamp window titles look like "#. Artist - Track - Winamp".
                                 // Require that the user use ATF and replace the format with something like:
-                                // %artist% – %title%
+                                // %artist% – %title% – %album%
                                 string windowTitleFull = winampTitle.Replace("- Winamp", string.Empty);
                                 string[] windowTitle = windowTitleFull.Split('–');
 
@@ -75,8 +75,9 @@ namespace Winter
                                 {
                                     string artist = windowTitle[0].Trim();
                                     string songTitle = windowTitle[1].Trim();
+				    string albumTitle = windowTitle[2].Trim();
 
-                                    TextHandler.UpdateText(songTitle, artist);
+                                    TextHandler.UpdateText(songTitle, artist, albumTitle);
                                 }
                                 else
                                 {

--- a/Snip/Players/Winamp.cs
+++ b/Snip/Players/Winamp.cs
@@ -75,7 +75,7 @@ namespace Winter
                                 {
                                     string artist = windowTitle[0].Trim();
                                     string songTitle = windowTitle[1].Trim();
-				    string albumTitle = windowTitle[2].Trim();
+                                    string albumTitle = windowTitle[2].Trim();
 
                                     TextHandler.UpdateText(songTitle, artist, albumTitle);
                                 }

--- a/Snip/Players/foobar2000.cs
+++ b/Snip/Players/foobar2000.cs
@@ -87,7 +87,7 @@ namespace Winter
                                 {
                                     string artist = windowTitle[0].Trim();
                                     string songTitle = windowTitle[1].Trim();
-				    string albumTitle = windowTitle[2].Trim();
+                                    string albumTitle = windowTitle[2].Trim();
 
                                     TextHandler.UpdateText(songTitle, artist, albumTitle);
                                 }

--- a/Snip/Players/foobar2000.cs
+++ b/Snip/Players/foobar2000.cs
@@ -71,9 +71,9 @@ namespace Winter
                             }
                             else
                             {
-                                // Winamp window titles look like "[%album artist% - ]['['%album%[ CD%discnumber%][ #%tracknumber%]']' ]%title%[ '//' %track artist%]".
+                                // Foobar2000 window titles look like "[%album artist% - ]['['%album%[ CD%discnumber%][ #%tracknumber%]']' ]%title%[ '//' %track artist%]".
                                 // Require that the user use ATF and replace the format with something like:
-                                // %artist% – %title%
+                                // %artist% – %title% – %album%
                                 string windowTitleFull = System.Text.RegularExpressions.Regex.Replace(foobar2000Title, @"\s+\[foobar2000.+\]", string.Empty);
                                 string[] windowTitle = windowTitleFull.Split('–');
 
@@ -87,8 +87,9 @@ namespace Winter
                                 {
                                     string artist = windowTitle[0].Trim();
                                     string songTitle = windowTitle[1].Trim();
+				    string albumTitle = windowTitle[2].Trim();
 
-                                    TextHandler.UpdateText(songTitle, artist);
+                                    TextHandler.UpdateText(songTitle, artist, albumTitle);
                                 }
                                 else
                                 {


### PR DESCRIPTION
I was wondering why Snip didn’t support album titles for Winamp and Foobar2000. Decided to look at the code and it looks like adding support for it should be trivial.

Sadly I have nothing set up here to compile .Net, so I can’t test if it _actually_ works :)