### PR TITLE
add quodlibet support

### DIFF
--- a/Snip/Globals.cs
+++ b/Snip/Globals.cs
@@ -95,7 +95,8 @@ namespace Winter
             Winamp = 2,
             foobar2000 = 3,
             VLC = 4,
-            GPMDP = 5
+            GPMDP = 5,
+            quodlibet = 6
         }
 
         public enum MediaCommand : int

--- a/Snip/Resources/Strings.cs-CZ.txt
+++ b/Snip/Resources/Strings.cs-CZ.txt
@@ -18,6 +18,7 @@ Winamp=Winamp
 foobar2000=foobar2000
 VLC=VLC
 GPMDP=GPMDP
+quodlibet=quodlibet
 
 ; This text is saved to the Snip.txt file when the user switches media players
 ; from the right-click context menu.
@@ -27,6 +28,7 @@ SwitchedToWinamp=Přepnuto na Winamp
 SwitchedTofoobar2000=Přepnuto na foobar2000
 SwitchedToVLC=Přepnuto na VLC
 SwitchedToGPMDP=Přepnuto na GPMDP
+SwitchedToQuodlibet=Přepnuto na quodlibet
 
 ; This text is saved to the Snip.txt file when Snip itself is running but Snip
 ; does not detect the selected media player as running.
@@ -36,6 +38,7 @@ WinampIsNotRunning=Winamp není spuštěn
 foobar2000IsNotRunning=foobar2000 není spuštěn
 VLCIsNotRunning=VLC není spuštěno
 GPMDPIsNotRunning=GPMDP není spuštěno
+QuodlibetIsNotRunning=quodlibet není spuštěno
 
 ; This text is saved to the Snip.txt file when no track is playing in the
 ; selected media file or when the user stops/pauses a playing track.

--- a/Snip/Resources/Strings.de-AT.txt
+++ b/Snip/Resources/Strings.de-AT.txt
@@ -18,6 +18,7 @@ Winamp=Winamp
 foobar2000=foobar2000
 VLC=VLC
 GPMDP=GPMDP
+quodlibet=quodlibet
 
 ; This text is saved to the Snip.txt file when the user switches media players
 ; from the right-click context menu.
@@ -27,6 +28,7 @@ SwitchedToWinamp=Auf Winamp gewechselt
 SwitchedTofoobar2000=Auf foobar2000 gewechselt
 SwitchedToVLC=Auf VLC gewechselt
 SwitchedToGPMDP=Auf GPMDP gewechselt
+SwitchedToQuodlibet=Auf quodlibet gewechselt
 
 ; This text is saved to the Snip.txt file when Snip itself is running but Snip
 ; does not detect the selected media player as running.
@@ -36,6 +38,7 @@ WinampIsNotRunning=Winamp läuft gerade nicht
 foobar2000IsNotRunning=foobar2000 läuft gerade nicht
 VLCIsNotRunning=VLC läuft gerade nicht
 GPMDPIsNotRunning=GPMDP läuft gerade nicht
+QuodlibetIsNotRunning=quodlibet läuft gerade nicht
 
 ; This text is saved to the Snip.txt file when no track is playing in the
 ; selected media file or when the user stops/pauses a playing track.

--- a/Snip/Resources/Strings.de-CH.txt
+++ b/Snip/Resources/Strings.de-CH.txt
@@ -18,6 +18,7 @@ Winamp=Winamp
 foobar2000=foobar2000
 VLC=VLC
 GPMDP=GPMDP
+quodlibet=quodlibet
 
 ; This text is saved to the Snip.txt file when the user switches media players
 ; from the right-click context menu.
@@ -27,6 +28,7 @@ SwitchedToWinamp=Auf Winamp gewechselt
 SwitchedTofoobar2000=Auf foobar2000 gewechselt
 SwitchedToVLC=Auf VLC gewechselt
 SwitchedToGPMDP=Auf GPMDP gewechselt
+SwitchedToQuodlibet=Auf quodlibet gewechselt
 
 ; This text is saved to the Snip.txt file when Snip itself is running but Snip
 ; does not detect the selected media player as running.
@@ -36,6 +38,7 @@ WinampIsNotRunning=Winamp läuft gerade nicht
 foobar2000IsNotRunning=foobar2000 läuft gerade nicht
 VLCIsNotRunning=VLC läuft gerade nicht
 GPMDPIsNotRunning=GPMDP läuft gerade nicht
+QuodlibetIsNotRunning=quodlibet läuft gerade nicht
 
 ; This text is saved to the Snip.txt file when no track is playing in the
 ; selected media file or when the user stops/pauses a playing track.

--- a/Snip/Resources/Strings.de-DE.txt
+++ b/Snip/Resources/Strings.de-DE.txt
@@ -18,6 +18,7 @@ Winamp=Winamp
 foobar2000=foobar2000
 VLC=VLC
 GPMDP=GPMDP
+quodlibet=quodlibet
 
 ; This text is saved to the Snip.txt file when the user switches media players
 ; from the right-click context menu.
@@ -27,6 +28,7 @@ SwitchedToWinamp=Auf Winamp gewechselt
 SwitchedTofoobar2000=Auf foobar2000 gewechselt
 SwitchedToVLC=Auf VLC gewechselt
 SwitchedToGPMDP=Auf GPMDP gewechselt
+SwitchedToQuodlibet=Auf quodlibet gewechselt
 
 ; This text is saved to the Snip.txt file when Snip itself is running but Snip
 ; does not detect the selected media player as running.
@@ -36,6 +38,7 @@ WinampIsNotRunning=Winamp läuft gerade nicht
 foobar2000IsNotRunning=foobar2000 läuft gerade nicht
 VLCIsNotRunning=VLC läuft gerade nicht
 GPMDPIsNotRunning=GPMDP läuft gerade nicht
+QuodlibetIsNotRunning=quodlibet läuft gerade nicht
 
 ; This text is saved to the Snip.txt file when no track is playing in the
 ; selected media file or when the user stops/pauses a playing track.

--- a/Snip/Resources/Strings.el-GR.txt
+++ b/Snip/Resources/Strings.el-GR.txt
@@ -18,6 +18,7 @@ Winamp=Winamp
 foobar2000=foobar2000
 VLC=VLC
 GPMDP=GPMDP
+quodlibet=quodlibet
 
 ; This text is saved to the Snip.txt file when the user switches media players
 ; from the right-click context menu.
@@ -27,6 +28,7 @@ SwitchedToWinamp=Έγινε αλλαγή σε Winamp
 SwitchedTofoobar2000=Έγινε αλλαγή σε foobar2000
 SwitchedToVLC=Έγινε αλλαγή σε VLC
 SwitchedToGPMDP=Έγινε αλλαγή σε GPMDP
+SwitchedToQuodlibet=Έγινε αλλαγή σε quodlibet
 
 ; This text is saved to the Snip.txt file when Snip itself is running but Snip
 ; does not detect the selected media player as running.
@@ -36,6 +38,7 @@ WinampIsNotRunning=Το Winamp δεν εκτελείται αυτή τη στι�
 foobar2000IsNotRunning=Το foobar2000 δεν εκτελείται αυτή τη στιγμή
 VLCIsNotRunning=Το VLC δεν εκτελείται αυτή τη στιγμή
 GPMDPIsNotRunning=Το GPMDP δεν εκτελείται αυτή τη στιγμή
+QuodlibetIsNotRunning=Το quodlibet δεν εκτελείται αυτή τη στιγμή
 
 ; This text is saved to the Snip.txt file when no track is playing in the
 ; selected media file or when the user stops/pauses a playing track.

--- a/Snip/Resources/Strings.es-CL.txt
+++ b/Snip/Resources/Strings.es-CL.txt
@@ -18,6 +18,7 @@ Winamp=Winamp
 foobar2000=foobar2000
 VLC=VLC
 GPMDP=GPMDP
+quodlibet=quodlibet
 
 ; This text is saved to the Snip.txt file when the user switches media players
 ; from the right-click context menu.
@@ -27,6 +28,7 @@ SwitchedToWinamp=Se cambió a Winamp
 SwitchedTofoobar2000=Se cambió a foobar2000
 SwitchedToVLC=Se cambió a VLC
 SwitchedToGPMDP=Se cambió a GPMDP
+SwitchedToQuodlibet=Se cambió a quodlibet
 
 ; This text is saved to the Snip.txt file when Snip itself is running but Snip
 ; does not detect the selected media player as running.
@@ -36,6 +38,7 @@ WinampIsNotRunning=Winamp no se está ejecutando
 foobar2000IsNotRunning=foobar2000 no se está ejecutando
 VLCIsNotRunning=VLC no se está ejecutando
 GPMDPIsNotRunning=GPMDP no se está ejecutando
+QuodlibetIsNotRunning=quodlibet no se está ejecutando
 
 ; This text is saved to the Snip.txt file when no track is playing in the
 ; selected media file or when the user stops/pauses a playing track.

--- a/Snip/Resources/Strings.fr-FR.txt
+++ b/Snip/Resources/Strings.fr-FR.txt
@@ -18,6 +18,7 @@ Winamp=Winamp
 foobar2000=foobar2000
 VLC=VLC
 GPMDP=GPMDP
+quodlibet=quodlibet
 
 ; This text is saved to the Snip.txt file when the user switches media players
 ; from the right-click context menu.
@@ -27,6 +28,7 @@ SwitchedToWinamp=Changer à Winamp
 SwitchedTofoobar2000=Changer à foobar2000
 SwitchedToVLC=Changer à VLC
 SwitchedToGPMDP=Changer à GPMDP
+SwitchedToQuodlibet=Changer à quodlibet
 
 ; This text is saved to the Snip.txt file when Snip itself is running but Snip
 ; does not detect the selected media player as running.
@@ -36,6 +38,7 @@ WinampIsNotRunning=Winamp n'est pas en fonction présentement
 foobar2000IsNotRunning=foobar2000 n'est pas en fonction présentement
 VLCIsNotRunning=VLC n'est pas en fonction présentement
 GPMDPIsNotRunning=GPMDP n'est pas en fonction présentement
+QuodlibetIsNotRunning=quodlibet n'est pas en fonction présentement
 
 ; This text is saved to the Snip.txt file when no track is playing in the
 ; selected media file or when the user stops/pauses a playing track.

--- a/Snip/Resources/Strings.nb-NO.txt
+++ b/Snip/Resources/Strings.nb-NO.txt
@@ -18,6 +18,7 @@ Winamp=Winamp
 foobar2000=foobar2000
 VLC=VLC
 GPMDP=GPMDP
+quodlibet=quodlibet
 
 ; This text is saved to the Snip.txt file when the user switches media players
 ; from the right-click context menu.
@@ -27,6 +28,7 @@ SwitchedToWinamp=Byttet til Winamp
 SwitchedTofoobar2000=Byttet til foobar2000
 SwitchedToVLC=Byttet til VLC
 SwitchedToGPMDP=Byttet til GPMDP
+SwitchedToQuodlibet=Byttet til quodlibet
 
 ; This text is saved to the Snip.txt file when Snip itself is running but Snip
 ; does not detect the selected media player as running.
@@ -36,6 +38,7 @@ WinampIsNotRunning=Winamp kjører ikke
 foobar2000IsNotRunning=foobar2000 kjører ikke
 VLCIsNotRunning=VLC kjører ikke
 GPMDPIsNotRunning=GPMDP kjører ikke
+QuodlibetIsNotRunning=quodlibet kjører ikke
 
 ; This text is saved to the Snip.txt file when no track is playing in the
 ; selected media file or when the user stops/pauses a playing track.

--- a/Snip/Resources/Strings.nl-NL.txt
+++ b/Snip/Resources/Strings.nl-NL.txt
@@ -18,6 +18,7 @@ Winamp=Winamp
 foobar2000=foobar2000
 VLC=VLC
 GPMDP=GPMDP
+quodlibet=quodlibet
 
 ; This text is saved to the Snip.txt file when the user switches media players
 ; from the right-click context menu.
@@ -27,6 +28,7 @@ SwitchedToWinamp=Omgeschakeld naar Winamp
 SwitchedTofoobar2000=Omgeschakeld naar foobar2000
 SwitchedToVLC=Omgeschakeld naar VLC
 SwitchedToGPMDP=Omgeschakeld naar GPMDP
+SwitchedToQuodlibet=Omgeschakeld naar quodlibet
 
 ; This text is saved to the Snip.txt file when Snip itself is running but Snip
 ; does not detect the selected media player as running.
@@ -36,6 +38,7 @@ WinampIsNotRunning=Winamp draait nu niet
 foobar2000IsNotRunning=foobar2000 draait nu niet
 VLCIsNotRunning=VLC draait nu niet
 GPMDPIsNotRunning=GPMDP draait nu niet
+QuodlibetIsNotRunning=quodlibet draait nu niet
 
 ; This text is saved to the Snip.txt file when no track is playing in the
 ; selected media file or when the user stops/pauses a playing track.

--- a/Snip/Resources/Strings.pl-PL.txt
+++ b/Snip/Resources/Strings.pl-PL.txt
@@ -18,6 +18,7 @@ Winamp=Winamp
 foobar2000=foobar2000
 VLC=VLC
 GPMDP=GPMDP
+quodlibet=quodlibet
 
 ; This text is saved to the Snip.txt file when the user switches media players
 ; from the right-click context menu.
@@ -27,6 +28,7 @@ SwitchedToWinamp=Przełączono na Winamp
 SwitchedTofoobar2000=Przełączono na foobar2000
 SwitchedToVLC=Przełączono na VLC
 SwitchedToGPMDP=Przełączono na GPMDP
+SwitchedToQuodlibet=Przełączono na quodlibet
 
 ; This text is saved to the Snip.txt file when Snip itself is running but Snip
 ; does not detect the selected media player as running.
@@ -36,6 +38,7 @@ WinampIsNotRunning=Winamp nie jest obecnie uruchomione
 foobar2000IsNotRunning=foobar2000 nie jest obecnie uruchomione
 VLCIsNotRunning=VLC nie jest obecnie uruchomione
 GPMDPIsNotRunning=GPMDP nie jest obecnie uruchomione
+QuodlibetIsNotRunning=quodlibet nie jest obecnie uruchomione
 
 ; This text is saved to the Snip.txt file when no track is playing in the
 ; selected media file or when the user stops/pauses a playing track.

--- a/Snip/Resources/Strings.sv-SE.txt
+++ b/Snip/Resources/Strings.sv-SE.txt
@@ -18,6 +18,7 @@ Winamp=Winamp
 foobar2000=foobar2000
 VLC=VLC
 GPMDP=GPMDP
+quodlibet=quodlibet
 
 ; This text is saved to the Snip.txt file when the user switches media players
 ; from the right-click context menu.
@@ -27,6 +28,7 @@ SwitchedToWinamp=Bytte till Winamp
 SwitchedTofoobar2000=Bytte till foobar2000
 SwitchedToVLC=Bytte till VLC
 SwitchedToGPMDP=Bytte till GPMDP
+SwitchedToQuodlibet=Bytte till quodlibet
 
 ; This text is saved to the Snip.txt file when Snip itself is running but Snip
 ; does not detect the selected media player as running.
@@ -36,6 +38,7 @@ WinampIsNotRunning=Winamp körs inte just nu
 foobar2000IsNotRunning=foobar2000 körs inte just nu
 VLCIsNotRunning=VLC körs inte just nu
 GPMDPIsNotRunning=GPMDP körs inte just nu
+QuodlibetIsNotRunning=quodlibet körs inte just nu
 
 ; This text is saved to the Snip.txt file when no track is playing in the
 ; selected media file or when the user stops/pauses a playing track.

--- a/Snip/Resources/Strings.txt
+++ b/Snip/Resources/Strings.txt
@@ -18,6 +18,7 @@ Winamp=Winamp
 foobar2000=foobar2000
 VLC=VLC
 GPMDP=GPMDP
+quodlibet=quodlibet
 
 ; This text is saved to the Snip.txt file when the user switches media players
 ; from the right-click context menu.
@@ -27,6 +28,7 @@ SwitchedToWinamp=Switched to Winamp
 SwitchedTofoobar2000=Switched to foobar2000
 SwitchedToVLC=Switched to VLC
 SwitchedToGPMDP=Switched to GPMDP
+SwitchedToQuodlibet=Switched to quodlibet
 
 ; This text is saved to the Snip.txt file when Snip itself is running but Snip
 ; does not detect the selected media player as running.
@@ -36,6 +38,7 @@ WinampIsNotRunning=Winamp is not currently running
 foobar2000IsNotRunning=foobar2000 is not currently running
 VLCIsNotRunning=VLC is not currently running
 GPMDPIsNotRunning=GPMDP is not currently running
+QuodlibetIsNotRunning=quodlibet is not currently running
 
 ; This text is saved to the Snip.txt file when no track is playing in the
 ; selected media file or when the user stops/pauses a playing track.

--- a/Snip/Snip.Designer.cs
+++ b/Snip/Snip.Designer.cs
@@ -12,6 +12,7 @@
         private System.Windows.Forms.ToolStripMenuItem toolStripMenuItemFoobar2000;
         private System.Windows.Forms.ToolStripMenuItem toolStripMenuItemVlc;
         private System.Windows.Forms.ToolStripMenuItem toolStripMenuItemGPMDP;
+        private System.Windows.Forms.ToolStripMenuItem toolStripMenuItemQuodlibet;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator1;
         private System.Windows.Forms.ToolStripMenuItem toolStripMenuItemSetFormat;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator2;
@@ -74,6 +75,7 @@
             this.toolStripMenuItemFoobar2000 = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripMenuItemVlc = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripMenuItemGPMDP = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripMenuItemQuodlibet = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
             this.toolStripMenuItemSetFormat = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
@@ -112,6 +114,7 @@
             this.toolStripMenuItemFoobar2000,
             this.toolStripMenuItemVlc,
             this.toolStripMenuItemGPMDP,
+            this.toolStripMenuItemQuodlibet,
             this.toolStripSeparator1,
             this.toolStripMenuItemSetFormat,
             this.toolStripSeparator2,
@@ -171,6 +174,13 @@
             this.toolStripMenuItemVlc.Size = new System.Drawing.Size(67, 22);
             this.toolStripMenuItemVlc.Text = Globals.ResourceManager.GetString("VLC");
             this.toolStripMenuItemVlc.Click += new System.EventHandler(this.PlayerSelectionCheck);
+            // 
+            // toolStripMenuItemQuodlibet
+            // 
+            this.toolStripMenuItemQuodlibet.Name = "toolStripMenuItemQuodlibet";
+            this.toolStripMenuItemQuodlibet.Size = new System.Drawing.Size(67, 22);
+            this.toolStripMenuItemQuodlibet.Text = Globals.ResourceManager.GetString("quodlibet");
+            this.toolStripMenuItemQuodlibet.Click += new System.EventHandler(this.PlayerSelectionCheck);
             //
             // toolStripMenuItemGPMDP
             //

--- a/Snip/Snip.cs
+++ b/Snip/Snip.cs
@@ -156,6 +156,10 @@ namespace Winter
                 case Globals.MediaPlayerSelection.GPMDP:
                     this.ToggleGPMDP();
                     break;
+
+                case Globals.MediaPlayerSelection.quodlibet:
+                    this.ToggleQuodlibet();
+                    break;
             }
 
             this.toolStripMenuItemSaveSeparateFiles.Checked = Globals.SaveSeparateFiles;
@@ -243,6 +247,10 @@ namespace Winter
             {
                 this.ToggleGPMDP();
             }
+            else if (sender == this.toolStripMenuItemQuodlibet)
+            {
+                this.ToggleQuodlibet();
+            }
         }
 
         private void ToggleSpotify()
@@ -253,6 +261,7 @@ namespace Winter
             this.toolStripMenuItemFoobar2000.Checked = false;
             this.toolStripMenuItemVlc.Checked = false;
             this.toolStripMenuItemGPMDP.Checked = false;
+            this.toolStripMenuItemQuodlibet.Checked = false;
 
             Globals.CurrentPlayer.Unload();
             Globals.CurrentPlayer = new Spotify();
@@ -270,6 +279,7 @@ namespace Winter
             this.toolStripMenuItemFoobar2000.Checked = false;
             this.toolStripMenuItemVlc.Checked = false;
             this.toolStripMenuItemGPMDP.Checked = false;
+            this.toolStripMenuItemQuodlibet.Checked = false;
 
             Globals.CurrentPlayer.Unload();
             Globals.CurrentPlayer = new iTunes();
@@ -287,6 +297,7 @@ namespace Winter
             this.toolStripMenuItemFoobar2000.Checked = false;
             this.toolStripMenuItemVlc.Checked = false;
             this.toolStripMenuItemGPMDP.Checked = false;
+            this.toolStripMenuItemQuodlibet.Checked = false;
 
             Globals.CurrentPlayer.Unload();
             Globals.CurrentPlayer = new Winamp();
@@ -304,6 +315,7 @@ namespace Winter
             this.toolStripMenuItemFoobar2000.Checked = true;
             this.toolStripMenuItemVlc.Checked = false;
             this.toolStripMenuItemGPMDP.Checked = false;
+            this.toolStripMenuItemQuodlibet.Checked = false;
 
             Globals.CurrentPlayer.Unload();
             Globals.CurrentPlayer = new foobar2000();
@@ -321,6 +333,7 @@ namespace Winter
             this.toolStripMenuItemFoobar2000.Checked = false;
             this.toolStripMenuItemVlc.Checked = true;
             this.toolStripMenuItemGPMDP.Checked = false;
+            this.toolStripMenuItemQuodlibet.Checked = false;
 
             Globals.CurrentPlayer.Unload();
             Globals.CurrentPlayer = new VLC();
@@ -338,6 +351,7 @@ namespace Winter
             this.toolStripMenuItemFoobar2000.Checked = false;
             this.toolStripMenuItemVlc.Checked = false;
             this.toolStripMenuItemGPMDP.Checked = true;
+            this.toolStripMenuItemQuodlibet.Checked = false;
 
             Globals.CurrentPlayer.Unload();
             Globals.CurrentPlayer = new GPMDP();
@@ -345,6 +359,24 @@ namespace Winter
 
             Globals.PlayerSelection = Globals.MediaPlayerSelection.GPMDP;
             TextHandler.UpdateTextAndEmptyFilesMaybe(Globals.ResourceManager.GetString("SwitchedToGPMDP"));
+        }
+
+        private void ToggleQuodlibet()
+        {
+            this.toolStripMenuItemSpotify.Checked = false;
+            this.toolStripMenuItemItunes.Checked = false;
+            this.toolStripMenuItemWinamp.Checked = false;
+            this.toolStripMenuItemFoobar2000.Checked = false;
+            this.toolStripMenuItemVlc.Checked = false;
+            this.toolStripMenuItemGPMDP.Checked = false;
+            this.toolStripMenuItemQuodlibet.Checked = true;
+
+            Globals.CurrentPlayer.Unload();
+            Globals.CurrentPlayer = new quodlibet();
+            Globals.CurrentPlayer.Load();
+
+            Globals.PlayerSelection = Globals.MediaPlayerSelection.quodlibet;
+            TextHandler.UpdateTextAndEmptyFilesMaybe(Globals.ResourceManager.GetString("SwitchedToQuodlibet"));
         }
 
         private void ToolStripMenuItemSaveSeparateFiles_Click(object sender, EventArgs e)

--- a/Snip/Snip.csproj
+++ b/Snip/Snip.csproj
@@ -110,6 +110,7 @@
     <Compile Include="Players\iTunes.cs" />
     <Compile Include="Players\VLC.cs" />
     <Compile Include="Players\Winamp.cs" />
+    <Compile Include="Players\quodlibet.cs" />
     <Compile Include="Properties\Resources.Designer.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>

--- a/Snip/players/quodlibet.cs
+++ b/Snip/players/quodlibet.cs
@@ -1,0 +1,136 @@
+﻿#region File Information
+/*
+ * Copyright (C) 2012-2017 David Rudie
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02111, USA.
+ */
+#endregion
+
+namespace Winter
+{
+    using System;
+    using System.Diagnostics;
+
+    internal sealed class quodlibet : MediaPlayer
+    {
+        public override void Update()
+        {
+            Process[] processes = Process.GetProcessesByName("quodlibet");
+
+            if (processes.Length > 0)
+            {
+                string quodlibetTitle = string.Empty;
+
+                foreach (Process process in processes)
+                {
+                    quodlibetTitle = process.MainWindowTitle;
+                }
+
+                // Check for a hyphen in the title. If a hyphen exists then we need to cut all of the text after the last
+                // hyphen because that's the "quodlibet" text, which can vary based on language.
+                // If no hyphen exists then quodlibet is not playing anything.
+                int lastHyphen = quodlibetTitle.LastIndexOf("-", StringComparison.OrdinalIgnoreCase);
+
+                if (lastHyphen > 0)
+                {
+                    quodlibetTitle = quodlibetTitle.Substring(0, lastHyphen).Trim();
+
+                    if (Globals.SaveAlbumArtwork)
+                    {
+                        this.SaveBlankImage();
+                    }
+
+                    // Filter file extension
+                    // Using the previous method of using System.IO.Path to grab the file extension caused some problems.
+                    // It treated the title as a path, restricting what characters were allowed in the titles.
+                    // I changed it back to a similar version of the old method.
+                    // Now we'll check if the section of the title after the dot is greater than 4 characters, and less than 5 (the dot is included)
+                    // This is done because common file extensions are typically 3 characters long, with some exceptions like flac and aiff being 4.
+                    // Additionally, we'll check if there's a space anywhere after the last dot. Extensions will not have spaces in them.
+                    //
+                    // Alternatively, you can use System.IO.Path, make it system dependent, and replace characters like " and | with
+                    // equivalents.
+                    //
+                    // TODO:
+                    // It may be best to just remove common extensions by name, i.e. cut off ".mp3", ".flac", etc.
+                    int lastDot = quodlibetTitle.LastIndexOf(".", StringComparison.OrdinalIgnoreCase);
+                    if (lastDot > 0)
+                    {
+                        string quodlibetTitleExtension = quodlibetTitle.Substring(lastDot);
+                        if (quodlibetTitleExtension.Length >= 4 && quodlibetTitleExtension.Length <= 5 && !quodlibetTitleExtension.Contains(" "))
+                        {
+                            quodlibetTitle = quodlibetTitle.Substring(0, lastDot).Trim();
+                        }
+                    }
+
+                    TextHandler.UpdateText(quodlibetTitle);
+                }
+                else
+                {
+                    TextHandler.UpdateTextAndEmptyFilesMaybe(Globals.ResourceManager.GetString("NoTrackPlaying"));
+                }
+            }
+            else
+            {
+                if (Globals.SaveAlbumArtwork)
+                {
+                    this.SaveBlankImage();
+                }
+
+                TextHandler.UpdateTextAndEmptyFilesMaybe(Globals.ResourceManager.GetString("QuodlibetIsNotRunning"));
+            }
+        }
+
+        public override void Unload()
+        {
+            base.Unload();
+        }
+
+        public override void ChangeToNextTrack()
+        {
+            UnsafeNativeMethods.SendMessage(this.Handle, (uint)Globals.WindowMessage.AppCommand, IntPtr.Zero, new IntPtr((long)Globals.MediaCommand.NextTrack));
+        }
+
+        public override void ChangeToPreviousTrack()
+        {
+            UnsafeNativeMethods.SendMessage(this.Handle, (uint)Globals.WindowMessage.AppCommand, IntPtr.Zero, new IntPtr((long)Globals.MediaCommand.PreviousTrack));
+        }
+
+        public override void IncreasePlayerVolume()
+        {
+            UnsafeNativeMethods.SendMessage(this.Handle, (uint)Globals.WindowMessage.AppCommand, IntPtr.Zero, new IntPtr((long)Globals.MediaCommand.VolumeUp));
+        }
+
+        public override void DecreasePlayerVolume()
+        {
+            UnsafeNativeMethods.SendMessage(this.Handle, (uint)Globals.WindowMessage.AppCommand, IntPtr.Zero, new IntPtr((long)Globals.MediaCommand.VolumeDown));
+        }
+
+        public override void MutePlayerAudio()
+        {
+            UnsafeNativeMethods.SendMessage(this.Handle, (uint)Globals.WindowMessage.AppCommand, IntPtr.Zero, new IntPtr((long)Globals.MediaCommand.MuteTrack));
+        }
+
+        public override void PlayOrPauseTrack()
+        {
+            UnsafeNativeMethods.SendMessage(this.Handle, (uint)Globals.WindowMessage.AppCommand, IntPtr.Zero, new IntPtr((long)Globals.MediaCommand.PlayPauseTrack));
+        }
+
+        public override void StopTrack()
+        {
+            UnsafeNativeMethods.SendMessage(this.Handle, (uint)Globals.WindowMessage.AppCommand, IntPtr.Zero, new IntPtr((long)Globals.MediaCommand.StopTrack));
+        }
+    }
+}


### PR DESCRIPTION
quodlibet: https://quodlibet.readthedocs.io/en/latest/

quodlibet uses the same rules as VLC for creating the window title, so I was able to copy over the same logic from the VLC player file.