### PR TITLE
WIP: Simultaneous multiple players

### DIFF
--- a/Snip/Globals.cs
+++ b/Snip/Globals.cs
@@ -18,6 +18,9 @@
  */
 #endregion
 
+using System.Collections.Generic;
+using System.Web.UI;
+
 namespace Winter
 {
     using System.Resources;
@@ -48,10 +51,12 @@ namespace Winter
         public static ResourceManager ResourceManager { get; set; }
 
         public static MediaPlayer CurrentPlayer { get; set; }
+        public static List<MediaPlayer> LoadedPlayers { get; set; }
 
         public static NotifyIcon SnipNotifyIcon { get; set; }
 
-        public static MediaPlayerSelection PlayerSelection { get; set; }
+        public static Dictionary<MediaPlayerSelection, bool> PlayerSelection { get; } = new Dictionary<MediaPlayerSelection, bool>();
+
         public static bool SaveSeparateFiles { get; set; }
         public static bool SaveAlbumArtwork { get; set; }
         public static bool KeepSpotifyAlbumArtwork { get; set; }

--- a/Snip/Helpers.cs
+++ b/Snip/Helpers.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Winter
+{
+    public static class Helpers
+    {
+        public static Dictionary<TKey, TValue> Clone<TKey, TValue>
+            (this Dictionary<TKey, TValue> original)
+        {
+            Dictionary<TKey, TValue> ret = new Dictionary<TKey, TValue>(original.Count,
+                original.Comparer);
+            foreach (KeyValuePair<TKey, TValue> entry in original)
+            {
+                ret.Add(entry.Key, (TValue) entry.Value);
+            }
+            return ret;
+        }
+    }
+}

--- a/Snip/MediaPlayer.cs
+++ b/Snip/MediaPlayer.cs
@@ -138,5 +138,13 @@ namespace Winter
                 // File is in use... or something.  We can't write so we'll just bail out and hope no one notices.
             }
         }
+
+        /** Report that a song is currently playing.
+         * This sets the current media player as the target for hotkeys.
+         */
+        protected void SomethingIsPlaying()
+        {
+            Globals.CurrentPlayer = this;
+        }
     }
 }

--- a/Snip/MediaPlayer.cs
+++ b/Snip/MediaPlayer.cs
@@ -49,6 +49,10 @@ namespace Winter
 
         public bool NotRunning { get; set; }
 
+        private bool _somethingIsPlaying = false;
+
+        public bool IsSomethingPlaying => _somethingIsPlaying;
+
         public bool SavedBlankImage { get; set; }
 
         public IntPtr Handle { get; set; }
@@ -144,7 +148,13 @@ namespace Winter
          */
         protected void SomethingIsPlaying()
         {
+            this._somethingIsPlaying = true;
             Globals.CurrentPlayer = this;
+        }
+
+        protected void NothingIsPlaying()
+        {
+            this._somethingIsPlaying = false;
         }
     }
 }

--- a/Snip/Players/GPMDP.cs
+++ b/Snip/Players/GPMDP.cs
@@ -142,6 +142,8 @@ namespace Winter
                             {
                                 this.DownloadGPMDPAlbumArtwork(trackAlbumArt);
                             }
+                            
+                            this.SomethingIsPlaying();
 
                             this.LastTitle = lastTrack;
 
@@ -202,6 +204,8 @@ namespace Winter
                 }
 
                 TextHandler.UpdateTextAndEmptyFilesMaybe(Globals.ResourceManager.GetString("NoTrackPlaying"));
+                
+                this.NothingIsPlaying();
 
                 this.LastTitle = string.Empty;
 

--- a/Snip/Players/GPMDP.cs
+++ b/Snip/Players/GPMDP.cs
@@ -119,6 +119,8 @@ namespace Winter
                         if (lastTrack != this.LastTitle || Globals.RewriteUpdatedOutputFormat)
                         {
                             Globals.RewriteUpdatedOutputFormat = false;
+                            
+                            this.SomethingIsPlaying();
 
                             if (!string.IsNullOrEmpty(trackTitle) && !string.IsNullOrEmpty(trackArtist) && !string.IsNullOrEmpty(trackAlbum))
                             {
@@ -143,8 +145,6 @@ namespace Winter
                                 this.DownloadGPMDPAlbumArtwork(trackAlbumArt);
                             }
                             
-                            this.SomethingIsPlaying();
-
                             this.LastTitle = lastTrack;
 
                             this.gpmdpReset = false;
@@ -202,10 +202,11 @@ namespace Winter
                         this.SaveBlankImage();
                     }
                 }
+                
+                this.NothingIsPlaying();
 
                 TextHandler.UpdateTextAndEmptyFilesMaybe(Globals.ResourceManager.GetString("NoTrackPlaying"));
                 
-                this.NothingIsPlaying();
 
                 this.LastTitle = string.Empty;
 

--- a/Snip/Players/QuodLibet.cs
+++ b/Snip/Players/QuodLibet.cs
@@ -77,10 +77,12 @@ namespace Winter
                     }
 
                     TextHandler.UpdateText(quodLibetTitle);
+                    this.SomethingIsPlaying();
                 }
                 else
                 {
                     TextHandler.UpdateTextAndEmptyFilesMaybe(Globals.ResourceManager.GetString("NoTrackPlaying"));
+                    this.NothingIsPlaying();
                 }
             }
             else
@@ -95,6 +97,7 @@ namespace Winter
                         CultureInfo.InvariantCulture,
                         Globals.ResourceManager.GetString("PlayerIsNotRunning"),
                         Globals.ResourceManager.GetString("QuodLibet")));
+                this.NothingIsPlaying();
             }
         }
 

--- a/Snip/Players/QuodLibet.cs
+++ b/Snip/Players/QuodLibet.cs
@@ -76,13 +76,13 @@ namespace Winter
                         }
                     }
 
-                    TextHandler.UpdateText(quodLibetTitle);
                     this.SomethingIsPlaying();
+                    TextHandler.UpdateText(quodLibetTitle);
                 }
                 else
                 {
-                    TextHandler.UpdateTextAndEmptyFilesMaybe(Globals.ResourceManager.GetString("NoTrackPlaying"));
                     this.NothingIsPlaying();
+                    TextHandler.UpdateTextAndEmptyFilesMaybe(Globals.ResourceManager.GetString("NoTrackPlaying"));
                 }
             }
             else
@@ -92,12 +92,12 @@ namespace Winter
                     this.SaveBlankImage();
                 }
 
+                this.NothingIsPlaying();
                 TextHandler.UpdateTextAndEmptyFilesMaybe(
                     string.Format(
                         CultureInfo.InvariantCulture,
                         Globals.ResourceManager.GetString("PlayerIsNotRunning"),
                         Globals.ResourceManager.GetString("QuodLibet")));
-                this.NothingIsPlaying();
             }
         }
 

--- a/Snip/Players/Spotify.cs
+++ b/Snip/Players/Spotify.cs
@@ -309,6 +309,8 @@ namespace Winter
                                 this.DownloadSpotifyAlbumArtwork(jsonSummary.album);
                             }
 
+                            this.SomethingIsPlaying();
+
                             // Set the last title to the track id as these are unique values that only change when the track changes
                             this.LastTitle = trackId;
 
@@ -554,6 +556,7 @@ namespace Winter
                     {
                         downloadedJson = jsonWebClient.DownloadString(jsonAddress);
                     }
+
 
                     if (!string.IsNullOrEmpty(downloadedJson))
                     {

--- a/Snip/Players/Spotify.cs
+++ b/Snip/Players/Spotify.cs
@@ -644,6 +644,8 @@ namespace Winter
                 }
 
                 TextHandler.UpdateTextAndEmptyFilesMaybe(Globals.ResourceManager.GetString("NoTrackPlaying"));
+                
+                this.NothingIsPlaying();
 
                 this.LastTitle = string.Empty;
 
@@ -672,6 +674,7 @@ namespace Winter
                     CultureInfo.InvariantCulture,
                     Globals.ResourceManager.GetString("PlayerIsNotRunning"),
                     Globals.ResourceManager.GetString("Spotify")));
+            this.NothingIsPlaying();
         }
 
         private static Uri SelectAlbumArtworkSizeToDownload(dynamic jsonSummary)

--- a/Snip/Players/Spotify.cs
+++ b/Snip/Players/Spotify.cs
@@ -298,6 +298,8 @@ namespace Winter
 
                             artists = artists.Substring(0, artists.LastIndexOf(',')); // Removes last comma
 
+                            this.SomethingIsPlaying();
+                            
                             TextHandler.UpdateText(
                                 jsonSummary.name.ToString(),
                                 artists,
@@ -309,7 +311,6 @@ namespace Winter
                                 this.DownloadSpotifyAlbumArtwork(jsonSummary.album);
                             }
 
-                            this.SomethingIsPlaying();
 
                             // Set the last title to the track id as these are unique values that only change when the track changes
                             this.LastTitle = trackId;
@@ -643,9 +644,9 @@ namespace Winter
                     }
                 }
 
-                TextHandler.UpdateTextAndEmptyFilesMaybe(Globals.ResourceManager.GetString("NoTrackPlaying"));
-                
                 this.NothingIsPlaying();
+                
+                TextHandler.UpdateTextAndEmptyFilesMaybe(Globals.ResourceManager.GetString("NoTrackPlaying"));
 
                 this.LastTitle = string.Empty;
 
@@ -669,12 +670,13 @@ namespace Winter
                 }
             }
 
+            this.NothingIsPlaying();
+            
             TextHandler.UpdateTextAndEmptyFilesMaybe(
                 string.Format(
                     CultureInfo.InvariantCulture,
                     Globals.ResourceManager.GetString("PlayerIsNotRunning"),
                     Globals.ResourceManager.GetString("Spotify")));
-            this.NothingIsPlaying();
         }
 
         private static Uri SelectAlbumArtworkSizeToDownload(dynamic jsonSummary)

--- a/Snip/Players/VLC.cs
+++ b/Snip/Players/VLC.cs
@@ -89,8 +89,8 @@ namespace Winter
                 else
                 {
                     this.lastTitle = string.Empty;
-                    TextHandler.UpdateTextAndEmptyFilesMaybe(Globals.ResourceManager.GetString("NoTrackPlaying"));
                     this.NothingIsPlaying();
+                    TextHandler.UpdateTextAndEmptyFilesMaybe(Globals.ResourceManager.GetString("NoTrackPlaying"));
                 }
             }
             else
@@ -100,12 +100,13 @@ namespace Winter
                     this.SaveBlankImage();
                 }
 
+                this.NothingIsPlaying();
+                
                 TextHandler.UpdateTextAndEmptyFilesMaybe(
                     string.Format(
                         CultureInfo.InvariantCulture,
                         Globals.ResourceManager.GetString("PlayerIsNotRunning"),
                         Globals.ResourceManager.GetString("VLC")));
-                this.NothingIsPlaying();
             }
         }
 

--- a/Snip/Players/VLC.cs
+++ b/Snip/Players/VLC.cs
@@ -88,7 +88,9 @@ namespace Winter
                 }
                 else
                 {
+                    this.lastTitle = string.Empty;
                     TextHandler.UpdateTextAndEmptyFilesMaybe(Globals.ResourceManager.GetString("NoTrackPlaying"));
+                    this.NothingIsPlaying();
                 }
             }
             else
@@ -103,6 +105,7 @@ namespace Winter
                         CultureInfo.InvariantCulture,
                         Globals.ResourceManager.GetString("PlayerIsNotRunning"),
                         Globals.ResourceManager.GetString("VLC")));
+                this.NothingIsPlaying();
             }
         }
 

--- a/Snip/Players/VLC.cs
+++ b/Snip/Players/VLC.cs
@@ -26,6 +26,8 @@ namespace Winter
 
     internal sealed class VLC : MediaPlayer
     {
+        private string lastTitle = string.Empty;
+        
         public override void Update()
         {
             Process[] processes = Process.GetProcessesByName("vlc");
@@ -77,7 +79,12 @@ namespace Winter
                         }
                     }
 
-                    TextHandler.UpdateText(vlcTitle);
+                    if (vlcTitle != this.lastTitle)
+                    {
+                        this.SomethingIsPlaying();
+                        TextHandler.UpdateText(vlcTitle);
+                        this.lastTitle = vlcTitle;
+                    }
                 }
                 else
                 {

--- a/Snip/Players/Winamp.cs
+++ b/Snip/Players/Winamp.cs
@@ -55,8 +55,8 @@ namespace Winter
 
                             if (winampTitle.Contains("- Winamp [Stopped]") || winampTitle.Contains("- Winamp [Paused]"))
                             {
-                                TextHandler.UpdateTextAndEmptyFilesMaybe(Globals.ResourceManager.GetString("NoTrackPlaying"));
                                 this.NothingIsPlaying();
+                                TextHandler.UpdateTextAndEmptyFilesMaybe(Globals.ResourceManager.GetString("NoTrackPlaying"));
                             }
                             else
                             {
@@ -77,13 +77,13 @@ namespace Winter
                                     string artist = windowTitle[0].Trim();
                                     string songTitle = windowTitle[1].Trim();
 
-                                    TextHandler.UpdateText(songTitle, artist);
                                     this.SomethingIsPlaying();
+                                    TextHandler.UpdateText(songTitle, artist);
                                 }
                                 else
                                 {
-                                    TextHandler.UpdateText(windowTitle[0].Trim());
                                     this.SomethingIsPlaying();
+                                    TextHandler.UpdateText(windowTitle[0].Trim());
                                 }
                             }
 
@@ -99,14 +99,14 @@ namespace Winter
                                 this.SaveBlankImage();
                             }
 
+                            this.NothingIsPlaying();
+                            
                             TextHandler.UpdateTextAndEmptyFilesMaybe(
                                 string.Format(
                                     CultureInfo.InvariantCulture,
                                     Globals.ResourceManager.GetString("PlayerIsNotRunning"),
                                     Globals.ResourceManager.GetString("Winamp")));
                             
-                            this.NothingIsPlaying();
-
                             this.Found = false;
                             this.NotRunning = true;
                         }
@@ -121,13 +121,13 @@ namespace Winter
                             this.SaveBlankImage();
                         }
 
+                        this.NothingIsPlaying();
+                        
                         TextHandler.UpdateTextAndEmptyFilesMaybe(
                             string.Format(
                                 CultureInfo.InvariantCulture,
                                 Globals.ResourceManager.GetString("PlayerIsNotRunning"),
                                 Globals.ResourceManager.GetString("Winamp")));
-                        
-                        this.NothingIsPlaying();
 
                         this.Found = false;
                         this.NotRunning = true;

--- a/Snip/Players/Winamp.cs
+++ b/Snip/Players/Winamp.cs
@@ -56,6 +56,7 @@ namespace Winter
                             if (winampTitle.Contains("- Winamp [Stopped]") || winampTitle.Contains("- Winamp [Paused]"))
                             {
                                 TextHandler.UpdateTextAndEmptyFilesMaybe(Globals.ResourceManager.GetString("NoTrackPlaying"));
+                                this.NothingIsPlaying();
                             }
                             else
                             {
@@ -77,10 +78,12 @@ namespace Winter
                                     string songTitle = windowTitle[1].Trim();
 
                                     TextHandler.UpdateText(songTitle, artist);
+                                    this.SomethingIsPlaying();
                                 }
                                 else
                                 {
                                     TextHandler.UpdateText(windowTitle[0].Trim());
+                                    this.SomethingIsPlaying();
                                 }
                             }
 
@@ -101,6 +104,8 @@ namespace Winter
                                     CultureInfo.InvariantCulture,
                                     Globals.ResourceManager.GetString("PlayerIsNotRunning"),
                                     Globals.ResourceManager.GetString("Winamp")));
+                            
+                            this.NothingIsPlaying();
 
                             this.Found = false;
                             this.NotRunning = true;
@@ -121,6 +126,8 @@ namespace Winter
                                 CultureInfo.InvariantCulture,
                                 Globals.ResourceManager.GetString("PlayerIsNotRunning"),
                                 Globals.ResourceManager.GetString("Winamp")));
+                        
+                        this.NothingIsPlaying();
 
                         this.Found = false;
                         this.NotRunning = true;

--- a/Snip/Players/foobar2000.cs
+++ b/Snip/Players/foobar2000.cs
@@ -108,12 +108,12 @@ namespace Winter
                                 this.SaveBlankImage();
                             }
 
+                            this.NothingIsPlaying();
                             TextHandler.UpdateTextAndEmptyFilesMaybe(
                                 string.Format(
                                     CultureInfo.InvariantCulture,
                                     Globals.ResourceManager.GetString("PlayerIsNotRunning"),
                                     Globals.ResourceManager.GetString("foobar2000")));
-                            this.NothingIsPlaying();
 
                             this.Found = false;
                             this.NotRunning = true;
@@ -129,12 +129,12 @@ namespace Winter
                             this.SaveBlankImage();
                         }
 
+                        this.NothingIsPlaying();
                         TextHandler.UpdateTextAndEmptyFilesMaybe(
                             string.Format(
                                 CultureInfo.InvariantCulture,
                                 Globals.ResourceManager.GetString("PlayerIsNotRunning"),
                                 Globals.ResourceManager.GetString("foobar2000")));
-                        this.NothingIsPlaying();
 
                         this.Found = false;
                         this.NotRunning = true;

--- a/Snip/Players/foobar2000.cs
+++ b/Snip/Players/foobar2000.cs
@@ -113,6 +113,7 @@ namespace Winter
                                     CultureInfo.InvariantCulture,
                                     Globals.ResourceManager.GetString("PlayerIsNotRunning"),
                                     Globals.ResourceManager.GetString("foobar2000")));
+                            this.NothingIsPlaying();
 
                             this.Found = false;
                             this.NotRunning = true;
@@ -133,6 +134,7 @@ namespace Winter
                                 CultureInfo.InvariantCulture,
                                 Globals.ResourceManager.GetString("PlayerIsNotRunning"),
                                 Globals.ResourceManager.GetString("foobar2000")));
+                        this.NothingIsPlaying();
 
                         this.Found = false;
                         this.NotRunning = true;

--- a/Snip/Players/iTunes.cs
+++ b/Snip/Players/iTunes.cs
@@ -170,10 +170,12 @@ namespace Winter
                 }
 
                 TextHandler.UpdateText(track.Name, track.Artist, track.Album);
+                this.SomethingIsPlaying();
             }
             else if (!string.IsNullOrEmpty(this.iTunesApplication.CurrentStreamTitle))
             {
                 TextHandler.UpdateText(this.iTunesApplication.CurrentStreamTitle);
+                this.SomethingIsPlaying();
             }
         }
 

--- a/Snip/Players/iTunes.cs
+++ b/Snip/Players/iTunes.cs
@@ -187,6 +187,7 @@ namespace Winter
             }
 
             TextHandler.UpdateTextAndEmptyFilesMaybe(Globals.ResourceManager.GetString("NoTrackPlaying"));
+            this.NothingIsPlaying();
         }
 
         private void App_OnPlayerQuittingEvent()
@@ -201,6 +202,7 @@ namespace Winter
                     CultureInfo.InvariantCulture,
                     Globals.ResourceManager.GetString("PlayerIsNotRunning"),
                     Globals.ResourceManager.GetString("iTunes")));
+            this.NothingIsPlaying();
         }
     }
 }

--- a/Snip/Players/iTunes.cs
+++ b/Snip/Players/iTunes.cs
@@ -169,13 +169,13 @@ namespace Winter
                     }
                 }
 
-                TextHandler.UpdateText(track.Name, track.Artist, track.Album);
                 this.SomethingIsPlaying();
+                TextHandler.UpdateText(track.Name, track.Artist, track.Album);
             }
             else if (!string.IsNullOrEmpty(this.iTunesApplication.CurrentStreamTitle))
             {
-                TextHandler.UpdateText(this.iTunesApplication.CurrentStreamTitle);
                 this.SomethingIsPlaying();
+                TextHandler.UpdateText(this.iTunesApplication.CurrentStreamTitle);
             }
         }
 
@@ -186,8 +186,8 @@ namespace Winter
                 this.SaveBlankImage();
             }
 
-            TextHandler.UpdateTextAndEmptyFilesMaybe(Globals.ResourceManager.GetString("NoTrackPlaying"));
             this.NothingIsPlaying();
+            TextHandler.UpdateTextAndEmptyFilesMaybe(Globals.ResourceManager.GetString("NoTrackPlaying"));
         }
 
         private void App_OnPlayerQuittingEvent()
@@ -197,12 +197,12 @@ namespace Winter
                 this.SaveBlankImage();
             }
 
+            this.NothingIsPlaying();
             TextHandler.UpdateTextAndEmptyFilesMaybe(
                 string.Format(
                     CultureInfo.InvariantCulture,
                     Globals.ResourceManager.GetString("PlayerIsNotRunning"),
                     Globals.ResourceManager.GetString("iTunes")));
-            this.NothingIsPlaying();
         }
     }
 }

--- a/Snip/Settings.cs
+++ b/Snip/Settings.cs
@@ -1,4 +1,5 @@
 ﻿#region File Information
+
 /*
  * Copyright (C) 2012-2017 David Rudie
  *
@@ -16,7 +17,10 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02111, USA.
  */
+
 #endregion
+
+using System.Collections.Generic;
 
 namespace Winter
 {
@@ -36,7 +40,10 @@ namespace Winter
                     AssemblyInformation.AssemblyTitle,
                     Assembly.GetExecutingAssembly().GetName().Version.Major));
 
-            registryKey.SetValue("Player", (int)Globals.PlayerSelection);
+            foreach (KeyValuePair<Globals.MediaPlayerSelection, bool> pair in Globals.PlayerSelection)
+            {
+                registryKey.SetValue("Use " + Enum.GetName(typeof(Globals.MediaPlayerSelection), pair.Key), pair.Value);
+            }
 
             if (Globals.SaveSeparateFiles)
             {
@@ -65,7 +72,7 @@ namespace Winter
                 registryKey.SetValue("Keep Spotify Album Artwork", "false");
             }
 
-            registryKey.SetValue("Album Artwork Resolution", (int)Globals.ArtworkResolution);
+            registryKey.SetValue("Album Artwork Resolution", (int) Globals.ArtworkResolution);
 
             if (Globals.CacheSpotifyMetadata)
             {
@@ -126,9 +133,29 @@ namespace Winter
 
             if (registryKey != null)
             {
-                Globals.PlayerSelection = (Globals.MediaPlayerSelection)registryKey.GetValue("Player", Globals.MediaPlayerSelection.Spotify);
+                var hasAtLeastOne = false;
+                foreach (var type in Enum.GetValues(typeof(Globals.MediaPlayerSelection)))
+                {
+                    var value = registryKey.GetValue(
+                        "Use " + Enum.GetName(typeof(Globals.MediaPlayerSelection), type)
+                    );
+                    if (value != null)
+                    {
+                        var boolValue = Convert.ToBoolean(value);
+                        Globals.PlayerSelection.Add((Globals.MediaPlayerSelection) type, boolValue);
+                        if (boolValue)
+                        {
+                            hasAtLeastOne = true;
+                        }
+                    }
+                }
+                if (!hasAtLeastOne)
+                {
+                    Globals.PlayerSelection[Globals.MediaPlayerSelection.Spotify] = true;
+                }
 
-                bool saveSeparateFilesChecked = Convert.ToBoolean(registryKey.GetValue("Save Separate Files", false), CultureInfo.InvariantCulture);
+                bool saveSeparateFilesChecked = Convert.ToBoolean(registryKey.GetValue("Save Separate Files", false),
+                    CultureInfo.InvariantCulture);
                 if (saveSeparateFilesChecked)
                 {
                     Globals.SaveSeparateFiles = true;
@@ -138,7 +165,8 @@ namespace Winter
                     Globals.SaveSeparateFiles = false;
                 }
 
-                bool saveAlbumArtworkChecked = Convert.ToBoolean(registryKey.GetValue("Save Album Artwork", false), CultureInfo.InvariantCulture);
+                bool saveAlbumArtworkChecked = Convert.ToBoolean(registryKey.GetValue("Save Album Artwork", false),
+                    CultureInfo.InvariantCulture);
                 if (saveAlbumArtworkChecked)
                 {
                     Globals.SaveAlbumArtwork = true;
@@ -148,7 +176,9 @@ namespace Winter
                     Globals.SaveAlbumArtwork = false;
                 }
 
-                bool keepSpotifyAlbumArtwork = Convert.ToBoolean(registryKey.GetValue("Keep Spotify Album Artwork", false), CultureInfo.InvariantCulture);
+                bool keepSpotifyAlbumArtwork =
+                    Convert.ToBoolean(registryKey.GetValue("Keep Spotify Album Artwork", false),
+                        CultureInfo.InvariantCulture);
                 if (keepSpotifyAlbumArtwork)
                 {
                     Globals.KeepSpotifyAlbumArtwork = true;
@@ -158,9 +188,12 @@ namespace Winter
                     Globals.KeepSpotifyAlbumArtwork = false;
                 }
 
-                Globals.ArtworkResolution = (Globals.AlbumArtworkResolution)registryKey.GetValue("Album Artwork Resolution", Globals.AlbumArtworkResolution.Small);
+                Globals.ArtworkResolution =
+                    (Globals.AlbumArtworkResolution) registryKey.GetValue("Album Artwork Resolution",
+                        Globals.AlbumArtworkResolution.Small);
 
-                bool cacheSpotifyMetadata = Convert.ToBoolean(registryKey.GetValue("Cache Spotify Metadata", true), CultureInfo.InvariantCulture);
+                bool cacheSpotifyMetadata = Convert.ToBoolean(registryKey.GetValue("Cache Spotify Metadata", true),
+                    CultureInfo.InvariantCulture);
                 if (cacheSpotifyMetadata)
                 {
                     Globals.CacheSpotifyMetadata = true;
@@ -170,7 +203,8 @@ namespace Winter
                     Globals.CacheSpotifyMetadata = false;
                 }
 
-                bool saveHistoryChecked = Convert.ToBoolean(registryKey.GetValue("Save History", false), CultureInfo.InvariantCulture);
+                bool saveHistoryChecked = Convert.ToBoolean(registryKey.GetValue("Save History", false),
+                    CultureInfo.InvariantCulture);
                 if (saveHistoryChecked)
                 {
                     Globals.SaveHistory = true;
@@ -180,7 +214,8 @@ namespace Winter
                     Globals.SaveHistory = false;
                 }
 
-                bool displayTrackPopupChecked = Convert.ToBoolean(registryKey.GetValue("Display Track Popup", true), CultureInfo.InvariantCulture);
+                bool displayTrackPopupChecked = Convert.ToBoolean(registryKey.GetValue("Display Track Popup", true),
+                    CultureInfo.InvariantCulture);
                 if (displayTrackPopupChecked)
                 {
                     Globals.DisplayTrackPopup = true;
@@ -190,7 +225,8 @@ namespace Winter
                     Globals.DisplayTrackPopup = false;
                 }
 
-                bool emptyFileIfNoTrackPlayingChecked = Convert.ToBoolean(registryKey.GetValue("Empty File If No Track Playing", true), CultureInfo.InvariantCulture);
+                bool emptyFileIfNoTrackPlayingChecked = Convert.ToBoolean(
+                    registryKey.GetValue("Empty File If No Track Playing", true), CultureInfo.InvariantCulture);
                 if (emptyFileIfNoTrackPlayingChecked)
                 {
                     Globals.EmptyFileIfNoTrackPlaying = true;
@@ -200,7 +236,8 @@ namespace Winter
                     Globals.EmptyFileIfNoTrackPlaying = false;
                 }
 
-                bool enableHotkeysChecked = Convert.ToBoolean(registryKey.GetValue("Enable Hotkeys", true), CultureInfo.InvariantCulture);
+                bool enableHotkeysChecked = Convert.ToBoolean(registryKey.GetValue("Enable Hotkeys", true),
+                    CultureInfo.InvariantCulture);
                 if (enableHotkeysChecked)
                 {
                     Globals.EnableHotkeys = true;
@@ -210,19 +247,24 @@ namespace Winter
                     Globals.EnableHotkeys = false;
                 }
 
-                Globals.TrackFormat = Convert.ToString(registryKey.GetValue("Track Format", Globals.DefaultTrackFormat), CultureInfo.CurrentCulture);
+                Globals.TrackFormat = Convert.ToString(registryKey.GetValue("Track Format", Globals.DefaultTrackFormat),
+                    CultureInfo.CurrentCulture);
 
-                Globals.SeparatorFormat = Convert.ToString(registryKey.GetValue("Separator Format", Globals.DefaultSeparatorFormat), CultureInfo.CurrentCulture);
+                Globals.SeparatorFormat =
+                    Convert.ToString(registryKey.GetValue("Separator Format", Globals.DefaultSeparatorFormat),
+                        CultureInfo.CurrentCulture);
 
-                Globals.ArtistFormat = Convert.ToString(registryKey.GetValue("Artist Format", Globals.DefaultArtistFormat), CultureInfo.CurrentCulture);
+                Globals.ArtistFormat =
+                    Convert.ToString(registryKey.GetValue("Artist Format", Globals.DefaultArtistFormat),
+                        CultureInfo.CurrentCulture);
 
-                Globals.AlbumFormat = Convert.ToString(registryKey.GetValue("Album Format", Globals.DefaultAlbumFormat), CultureInfo.CurrentCulture);
+                Globals.AlbumFormat = Convert.ToString(registryKey.GetValue("Album Format", Globals.DefaultAlbumFormat),
+                    CultureInfo.CurrentCulture);
 
                 registryKey.Close();
             }
             else
             {
-                Globals.PlayerSelection = Globals.MediaPlayerSelection.Spotify;
                 Globals.SaveSeparateFiles = false;
                 Globals.SaveAlbumArtwork = false;
                 Globals.KeepSpotifyAlbumArtwork = false;

--- a/Snip/Snip.csproj
+++ b/Snip/Snip.csproj
@@ -99,6 +99,7 @@
     <Compile Include="CheckVersion.cs" />
     <Compile Include="Globals.cs" />
     <Compile Include="GlobalSuppressions.cs" />
+    <Compile Include="Helpers.cs" />
     <Compile Include="KeyboardHook.cs" />
     <Compile Include="OutputFormat.cs">
       <SubType>Form</SubType>

--- a/Snip/TextHandler.cs
+++ b/Snip/TextHandler.cs
@@ -69,6 +69,13 @@ namespace Winter
         {
             if (text != lastTextToWrite)
             {
+                // We don't want to write an empty file if something is playing in another player
+                if (text == Globals.ResourceManager.GetString("NoTrackPlaying") &&
+                    Globals.CurrentPlayer.IsSomethingPlaying)
+                {
+                    return;
+                }
+                
                 lastTextToWrite = text;
 
                 SetNotifyIconText(text);


### PR DESCRIPTION
This PR implements support for having multiple MediaPlayers running simultaneously, each reporting songs. A use case is when a user has iTunes and Spotify both open and plays songs from both (though not at the same time!)

This PR is still a work in progress. Current task list:

 -  [x] Implement core functions
 -  [x] Proof-of-concept with Spotify and VLC
 -  [x] Add support for all players
 -  [x] ~Bug: iTunes `HRESULT E_FAIL`~ **(EDIT: apparently not my fault, oops)**
 -  [ ] All the other inevitable bugs :-)