### PR TITLE
Cleared current song when closing Snip and during Spotify commercials

### DIFF
--- a/Snip/Snip.cs
+++ b/Snip/Snip.cs
@@ -124,7 +124,8 @@ namespace Winter
 
         private void Snip_FormClosing(object sender, FormClosingEventArgs e)
         {
-            // Save settings automatically when the form is being closed.
+            // Empty file and save settings automatically when the form is being closed.
+            TextHandler.UpdateTextAndEmptyFilesMaybe(Globals.ResourceManager.GetString("NoTrackPlaying"));
             Settings.Save();
         }
 


### PR DESCRIPTION
I was previously using Snaz but a new update from Spotify broke it so I looked for an alternative and found Snip. I noticed it was missing 2 features used in Snaz so I implemented them. Feel free to make suggestions if something can be improved.